### PR TITLE
HL-301: AXAHK - CLI tool credentials specific to AXAHK

### DIFF
--- a/src/config/config.mjs
+++ b/src/config/config.mjs
@@ -23,6 +23,10 @@ export async function getTenantWithEnvironment(alias) {
     endpoint: envConfig.endpoint
   }
 
+  if (tenant.jwt?.request?.headers) {
+    tenant.jwt.request.headers = tenant.jwt.request.headers.reduce((acc, { key, value }) => Object.assign(acc, { [key]: value }), {})
+  }
+
   return tenant
 }
 

--- a/src/login/login.mjs
+++ b/src/login/login.mjs
@@ -6,6 +6,11 @@ import {exit} from "node:process";
 import { getGraphEndpoint } from '../graph/api/api.js'
 
 export async function fetchNewToken(environment, tenant) {
+	if (tenant.jwt) return await fetchJwt(tenant.jwt)
+	return await fetchDefaultToken(environment, tenant)
+}
+
+async function fetchDefaultToken(environment, tenant) {
 	const query = gql`
 		query token($tenantId: String!, $clientId: String!, $username: String!, $password: String!) {
 			token_2(
@@ -44,4 +49,20 @@ export async function fetchNewToken(environment, tenant) {
 	catch (e) {
 		console.error(e)
 	}
+}
+
+async function fetchJwt({ request, property }) {
+	try {
+		const response = await axios(request)
+		const token = response.data[property]
+		if (!token) {
+			console.log(chalk.red(`Couldn't get token`))
+			exit(1)
+		}
+
+		return token
+	}
+	catch (e) {
+		console.error(e)
+	}  
 }


### PR DESCRIPTION
Option 5 in [AXAHK - CLI tool credentials specific to AXAHK](https://covergo.atlassian.net/browse/HL-301) (see the comments section for more details).

Sample config:
```
tenants:
  axa_uat:
    jwt:
      request:
        url: "https://ut-papi.axa.com.hk/..."
        headers:
        - key: "x-axahk-msgid"
          value: "..."
        - key: "apikey"
          value: "..."
        - key: "Cookie"
          value: "..."
      property: "access_token"
```
See [AXAHK - Onboarding a new appid of JWT to AXA Nonprod Covergo Platforms](https://covergo.atlassian.net/browse/HL-292) for the `curl` command.